### PR TITLE
Update example README links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,4 @@
 
 ## For contributors
 
-- Please use the `pnpm -w generate:examples:standalone` command to keep the `src`, `patches` and `standalone` directories in sync.
+- Please use the `mono examples sync --direction src-to-standalone` command to keep the `src`, `patches` and `standalone` directories in sync.

--- a/examples/src/web-linearlite/README.md
+++ b/examples/src/web-linearlite/README.md
@@ -1,0 +1,3 @@
+# Linearlite Example
+
+[Demo](https://web-linearlite.livestore.dev/)

--- a/examples/src/web-todomvc-custom-elements/README.md
+++ b/examples/src/web-todomvc-custom-elements/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc-experimental/README.md
+++ b/examples/src/web-todomvc-experimental/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc-sync-cf/README.md
+++ b/examples/src/web-todomvc-sync-cf/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc-sync-cf.livestore.dev)
 
 ## Running locally
 

--- a/examples/src/web-todomvc-sync-electric/README.md
+++ b/examples/src/web-todomvc-sync-electric/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/src/web-todomvc/README.md
+++ b/examples/src/web-todomvc/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc.livestore.dev)
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-custom-elements/README.md
+++ b/examples/standalone/web-todomvc-custom-elements/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-experimental/README.md
+++ b/examples/standalone/web-todomvc-experimental/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-sync-cf/README.md
+++ b/examples/standalone/web-todomvc-sync-cf/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc-sync-cf.livestore.dev)
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc-sync-electric/README.md
+++ b/examples/standalone/web-todomvc-sync-electric/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+See links to demos in [the examples docs](https://docs.livestore.dev/examples).
 
 ## Running locally
 

--- a/examples/standalone/web-todomvc/README.md
+++ b/examples/standalone/web-todomvc/README.md
@@ -1,6 +1,6 @@
 # TodoMVC Example
 
-[Demo](https://todovmc.livestore.dev)
+[Demo](https://web-todomvc.livestore.dev)
 
 ## Running locally
 


### PR DESCRIPTION
## Summary
- update old todovmc domain references
- link to docs for other example READMEs
- document web-linearlite example

## Testing
- `pnpm -w generate:examples:standalone` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684074aec9c0832689dee5e0536091bc